### PR TITLE
Singular system: keep existing components

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GsvdInitialization"
 uuid = "2ac24108-be9c-42b8-8d78-6a4f62a87e7d"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["youdongguo <1010705897@qq.com> and contributors"]
 
 [deps]

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -198,8 +198,17 @@ end
 
 function init_W(X::AbstractArray{T}, W0::AbstractArray{T}, H0::AbstractArray{T}, Hadd::AbstractArray{T}; α = nothing) where T
     A, b, _, invHH, H0Hadd, XHaddt = obj_para(X, W0, H0, Hadd)
-    (isposdef(A) || sum(abs2, A) <= 1e-12) || @warn "A is not positive definite."
-    α = α === nothing ? nonneg_lsq(A, -b; alg=:fnnls, gram=true) : α
+    if α === nothing
+        if isposdef(A)
+            α = nonneg_lsq(A, -b; alg=:fnnls, gram=true)
+        else
+            # A is not positive definite: the QP min_{α≥0} α'Aα + 2b'α has no
+            # unique bounded minimum, so fnnls is not meaningful.  Fall back to
+            # α = 1 (keep existing components at their current scale).
+            sum(abs2, A) <= 1e-12 || @warn "A is not positive definite."
+            α = ones(T, size(A, 1))
+        end
+    end
     Wadd = XHaddt*invHH-W0*Diagonal(α[:])*H0Hadd*invHH
     return Wadd, abs.(α)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,17 @@ end
     β = GsvdInitialization.Wcols_modification(X, repeat(β0', size(W, 1)).*W, H)
     @test β.*β0 ≈ ones(3)
 
+    # When H0 is parallel to Hadd the Schur complement vanishes and A = 0, making
+    # the QP degenerate.  init_W must return finite results rather than throwing
+    # SingularException (which fnnls raises on Julia ≥ 1.12 for a zero pivot).
+    W0_deg = rand(Float64, 5, 1)
+    H0_deg = rand(Float64, 1, 8)
+    X_deg  = W0_deg * H0_deg
+    Hadd_deg = H0_deg   # parallel to H0 → Schur complement = 0 → A = 0
+    Wadd_deg, a_deg = GsvdInitialization.init_W(X_deg, W0_deg, H0_deg, Hadd_deg)
+    @test all(isfinite, Wadd_deg)
+    @test all(isfinite, a_deg)
+
 end
 
 @testset "joint optimize W and alpha" begin


### PR DESCRIPTION
When the NNLS system matrix is singular, default to keeping all components at their full values.