### PR TITLE
Solve several API issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,13 @@ This factorization is not perfect as two components are the same and two feature
 Then, running GSVD-NMF on X (also using NNSVD as initialization) and computing the new reconstruction error:
 
 ```julia
-Wgsvd, Hgsvd = gsvdnmf(X, 9=>10; alg = :cd, tol_final = 1e-4, tol_intermediate = 1e-2, maxiter = 10^12);
+julia> result_gsvd, Λ = gsvdnmf(X, 9=>10; alg = :cd, tol_final = 1e-4, tol_intermediate = 1e-2, maxiter = 10^12);
+julia> Wgsvd, Hgsvd = result_gsvd.W, result_gsvd.H;
 julia> sum(abs2, X-Wgsvd*Hgsvd)/sum(abs2, X)
 1.2322603074132593e-10
 ```
+
+`Λ` is the vector of generalized singular values that ranked the candidate augmentation directions, useful as a diagnostic for understanding which directions the algorithm chose.
 An imperfect factorization from `nnmf` alone was augmented by `gsvdnmf` to a perfect factorization.
 Here are the new components:
 
@@ -65,10 +68,10 @@ Here are the new components:
 
 ## Functions
 
-W, H = **gsvdnmf**(X::AbstractMatrix, ncomponents::Pair{Int,Int}; 
-                   tol_final=1e-4, 
-                   tol_intermediate=1e-4, 
-                   kwargs...)
+result, Λ = **gsvdnmf**(X::AbstractMatrix, ncomponents::Pair{Int,Int}; 
+                       tol_final=1e-4, 
+                       tol_intermediate=1e-4, 
+                       kwargs...)
 
 Perform "GSVD-NMF" on the data matrix `X`.
 
@@ -93,10 +96,10 @@ Other keyword arguments are passed to `NMF.nnmf`.
 
 -----
 
-W, H = **gsvdnmf**(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
-                   n2 = size(first(f), 2),
-                   tol_nmf=1e-4,
-                   kwargs...)
+result, Λ = **gsvdnmf**(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
+                       n2 = size(first(f), 2),
+                       tol_nmf=1e-4,
+                       kwargs...)
 
 Augment `W` and `H` to have `n2` components, subsequently polished by NMF.
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Perform "GSVD-NMF" on the data matrix `X`.
 Arguments:
 
 - `strategy`: optional augmentation strategy `(X, W0, H0, Hadd) -> (W_aug, H_aug)`.
-  Defaults to `GsvdInitialization.truncating`; pass `GsvdInitialization.joint` for the
-  alternative (joint-NNLS) bundled strategy, or supply your own.
+  Defaults to `GsvdInitialization.truncating`; pass `GsvdInitialization.joint_nnls`
+  for the alternative bundled strategy, or supply your own.
 
 - `X`: non-negative data matrix
 
@@ -131,7 +131,7 @@ Wadd, Hadd, S = **gsvdrecover**([strategy,] X, W0, H0, kadd, f)
 
 Augment components for `W` and `H` without polishing by NMF.
 `strategy` defaults to `GsvdInitialization.truncating`; pass
-`GsvdInitialization.joint` or a user-defined callable for alternative
+`GsvdInitialization.joint_nnls` or a user-defined callable for alternative
 augmentation paths.
 
 Outputs:

--- a/README.md
+++ b/README.md
@@ -68,14 +68,18 @@ Here are the new components:
 
 ## Functions
 
-result, Λ = **gsvdnmf**(X::AbstractMatrix, ncomponents::Pair{Int,Int}; 
-                       tol_final=1e-4, 
-                       tol_intermediate=1e-4, 
+result, Λ = **gsvdnmf**([strategy,] X::AbstractMatrix, ncomponents::Pair{Int,Int};
+                       tol_final=1e-4,
+                       tol_intermediate=1e-4,
                        kwargs...)
 
 Perform "GSVD-NMF" on the data matrix `X`.
 
 Arguments:
+
+- `strategy`: optional augmentation strategy `(X, W0, H0, Hadd) -> (W_aug, H_aug)`.
+  Defaults to `GsvdInitialization.truncating`; pass `GsvdInitialization.joint` for the
+  alternative (joint-NNLS) bundled strategy, or supply your own.
 
 - `X`: non-negative data matrix
 
@@ -96,7 +100,7 @@ Other keyword arguments are passed to `NMF.nnmf`.
 
 -----
 
-result, Λ = **gsvdnmf**(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
+result, Λ = **gsvdnmf**([strategy,] X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
                        n2 = size(first(f), 2),
                        tol_nmf=1e-4,
                        kwargs...)
@@ -104,6 +108,8 @@ result, Λ = **gsvdnmf**(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix
 Augment `W` and `H` to have `n2` components, subsequently polished by NMF.
 
 Arguments:
+
+- `strategy`: see above. Defaults to `GsvdInitialization.truncating`.
 
 - `X`: non-negative data matrix
 
@@ -121,9 +127,12 @@ Other keyword arguments are passed to `NMF.nnmf`.
 
 -----
 
-Wadd, Hadd, S = **gsvdrecover**(X, W0, H0, kadd, f)
+Wadd, Hadd, S = **gsvdrecover**([strategy,] X, W0, H0, kadd, f)
 
 Augment components for `W` and `H` without polishing by NMF.
+`strategy` defaults to `GsvdInitialization.truncating`; pass
+`GsvdInitialization.joint` or a user-defined callable for alternative
+augmentation paths.
 
 Outputs:
 

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -10,8 +10,12 @@ using SparseArrays: sparse
 export gsvdnmf,
        gsvdrecover
 
+@static if VERSION >= v"1.11"
+    eval(Meta.parse("public truncating, joint_nnls"))
+end
+
 """
-    result, Λ = gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
+    result, Λ = gsvdnmf([strategy,] X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
                        n2 = size(first(f), 2),
                        tol_nmf=1e-4,
                        kwargs...)
@@ -19,6 +23,12 @@ export gsvdnmf,
 Augment `W` and `H` to have `n2` components, subsequently polished by NMF.
 
 Arguments:
+
+- `strategy`: a callable `(X, W0, H0, Hadd) -> (W_augmented, H_augmented)` that
+  produces fully-assembled non-negative augmented factors from the candidate
+  directions `Hadd` ranked by [`init_H`](@ref). Defaults to
+  [`GsvdInitialization.truncating`](@ref); [`GsvdInitialization.joint_nnls`](@ref) is
+  the alternative (joint-NNLS) strategy.
 
 - `X`: non-negative data matrix
 
@@ -38,11 +48,10 @@ Returns the `NMF.NMFResult` from the polishing step (its `W` and `H` fields hold
 the augmented factors) and `Λ`, the generalized singular values that ranked the
 candidate augmentation directions.
 """
-function gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
+function gsvdnmf(strategy, X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
                  n2 = size(first(f), 2),
                  tol_nmf=1e-4,
                  alg = :cd,
-                 initW = :standard,
                  truncmult = 1e-5,
                  kwargs...)
     n1 = size(W, 2)
@@ -50,21 +59,29 @@ function gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
     kadd > 0 || throw(ArgumentError("The number of components to add must be positive; got n2 = $n2, size(W, 2) = $n1"))
     kadd <= n1 || throw(ArgumentError("The number of components to add must be less than initial number of components"))
     size(first(f), 2) >= n1 || throw(ArgumentError("The supplied SVD does not have enough components"))
-    W_recover, H_recover, Λ = gsvdrecover(X, copy(W), copy(H), kadd, f; initW=initW)
+    W_recover, H_recover, Λ = gsvdrecover(strategy, X, copy(W), copy(H), kadd, f)
     if alg == :multmse
         W_recover, H_recover = max.(W_recover, truncmult), max.(H_recover, truncmult)
     end
     result_recover = nnmf(X, n2; kwargs..., init=:custom, tol=tol_nmf, W0=copy(W_recover), H0=copy(H_recover))
     return result_recover, Λ
 end
-gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, n2::Int; kwargs...) = gsvdnmf(X, W, H, tsvd(X, n2); kwargs...)
+gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f; kwargs...) =
+    gsvdnmf(truncating, X, W, H, f; kwargs...)
+gsvdnmf(strategy, X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, n2::Int; kwargs...) =
+    gsvdnmf(strategy, X, W, H, tsvd(X, n2); kwargs...)
+gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, n2::Int; kwargs...) =
+    gsvdnmf(truncating, X, W, H, n2; kwargs...)
 
 """
-    result, Λ = gsvdnmf(X::AbstractMatrix, ncomponents::Pair{Int,Int}; tol_final=1e-4, tol_intermediate=1e-4, kwargs...)
+    result, Λ = gsvdnmf([strategy,] X::AbstractMatrix, ncomponents::Pair{Int,Int}; tol_final=1e-4, tol_intermediate=1e-4, kwargs...)
 
 Perform "GSVD-NMF" on the data matrix `X`.
 
 Arguments:
+
+- `strategy`: see the four-argument [`gsvdnmf`](@ref) method. Defaults to
+  [`GsvdInitialization.truncating`](@ref).
 
 - `X`: non-negative data matrix
 
@@ -83,20 +100,31 @@ Keyword arguments:
 
 Other keyword arguments are passed to `NMF.nnmf`.
 """
-function gsvdnmf(X::AbstractMatrix, ncomponents::Pair{Int,Int}; tol_final=1e-4, tol_intermediate=tol_final, initW = :standard, kwargs...)
+function gsvdnmf(strategy, X::AbstractMatrix, ncomponents::Pair{Int,Int}; tol_final=1e-4, tol_intermediate=tol_final, kwargs...)
     n1, n2 = ncomponents
     f = tsvd(X, n2)
     W0, H0 = nndsvd(X, n1; initdata = (U = f[1], S = f[2], V = f[3]))
     result_initial_nmf = nnmf(X, n1; kwargs..., init=:custom, tol=tol_intermediate, W0=copy(W0), H0=copy(H0))
     W_initial_nmf, H_initial_nmf = result_initial_nmf.W, result_initial_nmf.H
-    return gsvdnmf(X, W_initial_nmf, H_initial_nmf, f; kwargs..., n2=n2, tol_nmf=tol_final, initW=initW)
+    return gsvdnmf(strategy, X, W_initial_nmf, H_initial_nmf, f; kwargs..., n2=n2, tol_nmf=tol_final)
 end
-gsvdnmf(X::AbstractMatrix, ncomponents_final::Integer; kwargs...) = gsvdnmf(X, ncomponents_final-1 => ncomponents_final; kwargs...)
+gsvdnmf(X::AbstractMatrix, ncomponents::Pair{Int,Int}; kwargs...) =
+    gsvdnmf(truncating, X, ncomponents; kwargs...)
+gsvdnmf(strategy, X::AbstractMatrix, ncomponents_final::Integer; kwargs...) =
+    gsvdnmf(strategy, X, ncomponents_final-1 => ncomponents_final; kwargs...)
+gsvdnmf(X::AbstractMatrix, ncomponents_final::Integer; kwargs...) =
+    gsvdnmf(truncating, X, ncomponents_final; kwargs...)
 
 """
-    Wadd, Hadd, S = gsvdrecover(X, W0, H0, kadd, f)
+    Wadd, Hadd, S = gsvdrecover([strategy,] X, W0, H0, kadd, f)
 
 Augment components for `W` and `H` without polishing by NMF.
+
+`strategy` is a callable `(X, W0, H0, Hadd) -> (W_augmented, H_augmented)` that
+produces fully-assembled non-negative augmented factors from the candidate
+directions `Hadd` ranked by [`init_H`](@ref). Defaults to
+[`GsvdInitialization.truncating`](@ref); [`GsvdInitialization.joint_nnls`](@ref) is the
+alternative bundled strategy.
 
 Outputs:
 
@@ -118,28 +146,49 @@ Arguments:
 
 `f`: SVD (or Truncated SVD) of `X`
 """
-function gsvdrecover(X, W0::AbstractArray, H0::AbstractArray, kadd::Int, f::Tuple; initW::Symbol = :standard, kwargs...)
-    m, n = size(W0)
+function gsvdrecover(strategy, X, W0::AbstractArray, H0::AbstractArray, kadd::Int, f)
+    _, n = size(W0)
     kadd > 0 || throw(ArgumentError("kadd must be positive; got $kadd"))
     kadd <= n || throw(ArgumentError("# of extra columns must less than 1st NMF components"))
     U0, S0, V0 = f
     U0, S0, V0 = U0[:,1:n], S0[1:n], V0[:,1:n]
     Hadd, Λ = init_H(U0, S0, V0, W0, H0, kadd)
-    if initW == :standard
-        Wadd, a = init_W(X, W0, H0, Hadd)
-        Wadd_nn, Hadd_nn = nndsvd(X, kadd, initdata = (U = Wadd, S = ones(kadd), V = Hadd'))
-        W0_1, H0_1 = [repeat(a', m, 1).*W0 Wadd_nn], [H0; Hadd_nn]
-        cs = Wcols_modification(X, W0_1, H0_1)
-        W0_2, H0_2 = repeat(cs', m, 1).*W0_1, H0_1
-    elseif initW == :joint
-        W0_2, H0_2 = gsvdrecover_Wa(X, W0, H0, Hadd; kwargs...)
-    else
-        throw(ArgumentError("Unknown initW method: $initW"))
-    end
-    return abs.(W0_2), abs.(H0_2), Λ
+    W, H = strategy(X, W0, H0, Hadd)
+    return W, H, Λ
+end
+gsvdrecover(X, W0::AbstractArray, H0::AbstractArray, kadd::Int, f) =
+    gsvdrecover(truncating, X, W0, H0, kadd, f)
+
+"""
+    truncating(X, W0, H0, Hadd) -> (W_augmented, H_augmented)
+
+Default `gsvdrecover` strategy. Restricts the use of nonnegative least-squares (NNLS)
+to the component weights `α`, and uses least-squares followed by an NNDSVD step
+to solve for the new columns of `W` (i.e., `Wadd`).
+
+Returns non-negative `(W_augmented, H_augmented)`.
+"""
+function truncating(X, W0::AbstractArray, H0::AbstractArray, Hadd::AbstractArray)
+    m = size(W0, 1)
+    kadd = size(Hadd, 1)
+    Wadd, a = init_W(X, W0, H0, Hadd)
+    Wadd_nn, Hadd_nn = nndsvd(X, kadd, initdata = (U = Wadd, S = ones(kadd), V = Hadd'))
+    W0_1, H0_1 = [repeat(a', m, 1).*W0 Wadd_nn], [H0; Hadd_nn]
+    cs = Wcols_modification(X, W0_1, H0_1)
+    W0_2, H0_2 = repeat(cs', m, 1).*W0_1, H0_1
+    return abs.(W0_2), abs.(H0_2)
 end
 
-function gsvdrecover_Wa(X::AbstractArray, W0::AbstractArray, H0::AbstractArray, Hadd::AbstractArray)
+"""
+    joint_nnls(X, W0, H0, Hadd) -> (W_augmented, H_augmented)
+
+Alternative `gsvdrecover` strategy that jointly solves for the new columns of
+`W` and the rescaling `α` of existing columns using nonnegative least-squares
+(NNLS). `Hadd` is first projected onto the non-negative orthant.
+
+Returns non-negative `(W_augmented, H_augmented)`.
+"""
+function joint_nnls(X, W0::AbstractArray, H0::AbstractArray, Hadd::AbstractArray)
     m = size(W0, 1)
     Hadd_nn = truncatepos(Hadd', X, W0, H0)'
     Wadd, a = init_Wa(X, W0, H0, Hadd_nn)

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -43,19 +43,15 @@ function gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
                  kwargs...)
     n1 = size(W, 2)
     kadd = n2 - n1
-    kadd >= 0 || throw(ArgumentError("The number of components to add must be non-negative"))
+    kadd > 0 || throw(ArgumentError("The number of components to add must be positive; got n2 = $n2, size(W, 2) = $n1"))
     kadd <= n1 || throw(ArgumentError("The number of components to add must be less than initial number of components"))
     size(first(f), 2) >= n1 || throw(ArgumentError("The supplied SVD does not have enough components"))
-    if kadd == 0
-        return W, H
-    else
-        W_recover, H_recover, _ = gsvdrecover(X, copy(W), copy(H), kadd, f; initW=initW)
-        if alg == :multmse
-            W_recover, H_recover = max.(W_recover, truncmult), max.(H_recover, truncmult)
-        end
-        result_recover = nnmf(X, n2; kwargs..., init=:custom, tol=tol_nmf, W0=copy(W_recover), H0=copy(H_recover))
-        return result_recover, result_recover.W, result_recover.H
+    W_recover, H_recover, _ = gsvdrecover(X, copy(W), copy(H), kadd, f; initW=initW)
+    if alg == :multmse
+        W_recover, H_recover = max.(W_recover, truncmult), max.(H_recover, truncmult)
     end
+    result_recover = nnmf(X, n2; kwargs..., init=:custom, tol=tol_nmf, W0=copy(W_recover), H0=copy(H_recover))
+    return result_recover, result_recover.W, result_recover.H
 end
 gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, n2::Int; kwargs...) = gsvdnmf(X, W, H, tsvd(X, n2); kwargs...)
 
@@ -120,26 +116,23 @@ Arguments:
 """
 function gsvdrecover(X, W0::AbstractArray, H0::AbstractArray, kadd::Int, f::Tuple; initW::Symbol = :standard, kwargs...)
     m, n = size(W0)
+    kadd > 0 || throw(ArgumentError("kadd must be positive; got $kadd"))
     kadd <= n || throw(ArgumentError("# of extra columns must less than 1st NMF components"))
-    if kadd == 0
-        return W0, H0, 0
+    U0, S0, V0 = f
+    U0, S0, V0 = U0[:,1:n], S0[1:n], V0[:,1:n]
+    Hadd, Λ = init_H(U0, S0, V0, W0, H0, kadd)
+    if initW == :standard
+        Wadd, a = init_W(X, W0, H0, Hadd)
+        Wadd_nn, Hadd_nn = nndsvd(X, kadd, initdata = (U = Wadd, S = ones(kadd), V = Hadd'))
+        W0_1, H0_1 = [repeat(a', m, 1).*W0 Wadd_nn], [H0; Hadd_nn]
+        cs = Wcols_modification(X, W0_1, H0_1)
+        W0_2, H0_2 = repeat(cs', m, 1).*W0_1, H0_1
+    elseif initW == :joint
+        W0_2, H0_2 = gsvdrecover_Wa(X, W0, H0, Hadd; kwargs...)
     else
-        U0, S0, V0 = f
-        U0, S0, V0 = U0[:,1:n], S0[1:n], V0[:,1:n]
-        Hadd, Λ = init_H(U0, S0, V0, W0, H0, kadd)
-        if initW == :standard
-            Wadd, a = init_W(X, W0, H0, Hadd)
-            Wadd_nn, Hadd_nn = nndsvd(X, kadd, initdata = (U = Wadd, S = ones(kadd), V = Hadd'))
-            W0_1, H0_1 = [repeat(a', m, 1).*W0 Wadd_nn], [H0; Hadd_nn]
-            cs = Wcols_modification(X, W0_1, H0_1)
-            W0_2, H0_2 = repeat(cs', m, 1).*W0_1, H0_1
-        elseif initW == :joint
-            W0_2, H0_2 = gsvdrecover_Wa(X, W0, H0, Hadd; kwargs...)
-        else
-            throw(ArgumentError("Unknown initW method: $initW"))
-        end
-        return abs.(W0_2), abs.(H0_2), Λ
+        throw(ArgumentError("Unknown initW method: $initW"))
     end
+    return abs.(W0_2), abs.(H0_2), Λ
 end
 
 function gsvdrecover_Wa(X::AbstractArray, W0::AbstractArray, H0::AbstractArray, Hadd::AbstractArray)

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -11,10 +11,10 @@ export gsvdnmf,
        gsvdrecover
 
 """
-    W, H = gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
-                   n2 = size(first(f), 2),
-                   tol_nmf=1e-4,
-                   kwargs...)
+    result, Λ = gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
+                       n2 = size(first(f), 2),
+                       tol_nmf=1e-4,
+                       kwargs...)
 
 Augment `W` and `H` to have `n2` components, subsequently polished by NMF.
 
@@ -33,6 +33,10 @@ Keyword arguments:
 - `tol_nmf`: the tolerance of  NMF polishing step, default: 1e-4
 
 Other keyword arguments are passed to `NMF.nnmf`.
+
+Returns the `NMF.NMFResult` from the polishing step (its `W` and `H` fields hold
+the augmented factors) and `Λ`, the generalized singular values that ranked the
+candidate augmentation directions.
 """
 function gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
                  n2 = size(first(f), 2),
@@ -46,17 +50,17 @@ function gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f;
     kadd > 0 || throw(ArgumentError("The number of components to add must be positive; got n2 = $n2, size(W, 2) = $n1"))
     kadd <= n1 || throw(ArgumentError("The number of components to add must be less than initial number of components"))
     size(first(f), 2) >= n1 || throw(ArgumentError("The supplied SVD does not have enough components"))
-    W_recover, H_recover, _ = gsvdrecover(X, copy(W), copy(H), kadd, f; initW=initW)
+    W_recover, H_recover, Λ = gsvdrecover(X, copy(W), copy(H), kadd, f; initW=initW)
     if alg == :multmse
         W_recover, H_recover = max.(W_recover, truncmult), max.(H_recover, truncmult)
     end
     result_recover = nnmf(X, n2; kwargs..., init=:custom, tol=tol_nmf, W0=copy(W_recover), H0=copy(H_recover))
-    return result_recover, result_recover.W, result_recover.H
+    return result_recover, Λ
 end
 gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, n2::Int; kwargs...) = gsvdnmf(X, W, H, tsvd(X, n2); kwargs...)
 
 """
-    W, H = gsvdnmf(X::AbstractMatrix, ncomponents::Pair{Int,Int}; tol_final=1e-4, tol_intermediate=1e-4, kwargs...)
+    result, Λ = gsvdnmf(X::AbstractMatrix, ncomponents::Pair{Int,Int}; tol_final=1e-4, tol_intermediate=1e-4, kwargs...)
 
 Perform "GSVD-NMF" on the data matrix `X`.
 

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -191,7 +191,7 @@ Returns non-negative `(W_augmented, H_augmented)`.
 function joint_nnls(X, W0::AbstractArray, H0::AbstractArray, Hadd::AbstractArray)
     m = size(W0, 1)
     Hadd_nn = truncatepos(Hadd', X, W0, H0)'
-    Wadd, a = init_Wa(X, W0, H0, Hadd_nn)
+    Wadd, a = init_W_joint_nnls(X, W0, H0, Hadd_nn)
     W0_1, H0_1 = [repeat(a', m, 1).*W0 Wadd], [H0; Hadd_nn]
     return abs.(W0_1), abs.(H0_1)
 end
@@ -211,7 +211,7 @@ function init_H(U0::AbstractArray, S0::AbstractArray, V0::AbstractArray, W0::Abs
     return Hadd_1', Λ
 end
 
-function init_Wa(X::AbstractArray{T}, W0::AbstractArray{T}, H0::AbstractArray{T}, Hadd::AbstractArray{T}) where T
+function init_W_joint_nnls(X::AbstractArray{T}, W0::AbstractArray{T}, H0::AbstractArray{T}, Hadd::AbstractArray{T}) where T
     m = size(X, 1)
     kadd = size(Hadd, 1)
     G = gram_sp_C(W0, H0, Hadd)[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,11 +143,27 @@ end
     @test Hd ≈ Hf
 end
 
+@testset "strategy dispatch" begin
+    X = rand(30, 20)
+    # explicit `truncating` matches the no-strategy default
+    r_default, _ = gsvdnmf(X, 9 => 10; alg = :cd)
+    r_explicit, _ = gsvdnmf(GsvdInitialization.truncating, X, 9 => 10; alg = :cd)
+    @test r_default.W ≈ r_explicit.W
+    @test r_default.H ≈ r_explicit.H
+
+    # do-block form: anonymous strategy that simply forwards to `truncating`
+    r_doblock, _ = gsvdnmf(X, 9 => 10; alg = :cd) do X0, W0, H0, Hadd
+        GsvdInitialization.truncating(X0, W0, H0, Hadd)
+    end
+    @test r_doblock.W ≈ r_default.W
+    @test r_doblock.H ≈ r_default.H
+end
+
 @testset "joint optimize W and alpha" begin
     W = W_GT
     H = H_GT
     X = W*H
-    result_joint, _ = gsvdnmf(X, 9=>10; alg = :cd, maxiter = 10^5, tol_final=1e-4, tol_intermediate = 1e-4, initW=:joint);
+    result_joint, _ = gsvdnmf(GsvdInitialization.joint_nnls, X, 9=>10; alg = :cd, maxiter = 10^5, tol_final=1e-4, tol_intermediate = 1e-4);
     W_gsvd, H_gsvd = result_joint.W, result_joint.H
     @test size(W_gsvd, 2) == 10
     @test sum(abs2, X-W_gsvd*H_gsvd)/sum(abs2, X) < 2e-10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,7 +174,7 @@ end
 
     W0, H0 = copy(W), copy(H)
     Hadd = rand(2, 8)
-    Wadd, a = GsvdInitialization.init_Wa(X, W0, H0, Hadd)
+    Wadd, a = GsvdInitialization.init_W_joint_nnls(X, W0, H0, Hadd)
     @test a ≈ ones(size(W0, 2))
     @test norm(Wadd) <= 1e-8
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,14 +45,18 @@ svdX = load_svd_of_gt()
     H = H_GT
     X = W*H
     standard_nmf = nnmf(X, 10; alg = :cd, init=:nndsvd, tol=1e-4, maxiter = 10^5, initdata = svdX)
-    _, W_gsvd, H_gsvd = gsvdnmf(X, 9=>10; alg = :cd, maxiter = 10^5, tol_final=1e-4, tol_intermediate = 1e-4);
+    result_gsvd, Λ_gsvd = gsvdnmf(X, 9=>10; alg = :cd, maxiter = 10^5, tol_final=1e-4, tol_intermediate = 1e-4);
+    W_gsvd, H_gsvd = result_gsvd.W, result_gsvd.H
     @test size(W_gsvd, 2) == 10
     @test sum(abs2, X-W_gsvd*H_gsvd)/sum(abs2, X) < 2e-10
     @test sum(abs2, X-standard_nmf.W*standard_nmf.H)/sum(abs2, X) > sum(abs2, X-W_gsvd*H_gsvd)/sum(abs2, X)
+    @test length(Λ_gsvd) == 9
 
     X = rand(30, 20)
-    _, W_gsvd_1, H_gsvd_1 = gsvdnmf(X, 10; alg=:cd)
-    _, W_gsvd_2, H_gsvd_2 = gsvdnmf(X, 9 => 10; alg=:cd)
+    result_1, _ = gsvdnmf(X, 10; alg=:cd)
+    result_2, _ = gsvdnmf(X, 9 => 10; alg=:cd)
+    W_gsvd_1, H_gsvd_1 = result_1.W, result_1.H
+    W_gsvd_2, H_gsvd_2 = result_2.W, result_2.H
     @test sum(abs2, W_gsvd_1-W_gsvd_2) <= 1e-12
     @test sum(abs2, H_gsvd_1-H_gsvd_2) <= 1e-12
 
@@ -143,7 +147,8 @@ end
     W = W_GT
     H = H_GT
     X = W*H
-    _, W_gsvd, H_gsvd = gsvdnmf(X, 9=>10; alg = :cd, maxiter = 10^5, tol_final=1e-4, tol_intermediate = 1e-4, initW=:joint);
+    result_joint, _ = gsvdnmf(X, 9=>10; alg = :cd, maxiter = 10^5, tol_final=1e-4, tol_intermediate = 1e-4, initW=:joint);
+    W_gsvd, H_gsvd = result_joint.W, result_joint.H
     @test size(W_gsvd, 2) == 10
     @test sum(abs2, X-W_gsvd*H_gsvd)/sum(abs2, X) < 2e-10
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,14 @@ svdX = load_svd_of_gt()
     _, W_gsvd_2, H_gsvd_2 = gsvdnmf(X, 9 => 10; alg=:cd)
     @test sum(abs2, W_gsvd_1-W_gsvd_2) <= 1e-12
     @test sum(abs2, H_gsvd_1-H_gsvd_2) <= 1e-12
+
+    # n2 == size(W, 2) is a caller bug: there is nothing to augment.  Reject it
+    # eagerly rather than silently returning the input factorization.
+    Wfit, Hfit = rand(30, 5), rand(5, 20)
+    f = svd(X)
+    @test_throws ArgumentError gsvdnmf(X, Wfit, Hfit, (f.U, f.S, f.V); n2 = 5)
+    @test_throws "must be positive" gsvdnmf(X, Wfit, Hfit, (f.U, f.S, f.V); n2 = 5)
+    @test_throws "must be positive" gsvdrecover(X, Wfit, Hfit, 0, (f.U, f.S, f.V))
 end
 
 @testset "GsvdInitialization" begin


### PR DESCRIPTION
During review (see #22), several API issues were noted. This PR, containing four separate commits (which should remain separate), fixes them:

- the different arity of the return types depending on `kadd == 0` was fixed by making `kadd == 0` error.
- the singular values are very informative, return them
- remove redundant returns
- pass the choice of truncating or full-NNLS via a function argument

Fixes #22