### PR TITLE
Integration review: bug fixes, genericity, numerical hygiene, and test reproducibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ LinearAlgebra = "1"
 NMF = "1"
 NonNegLeastSquares = "0.4"
 SparseArrays = "1"
+StableRNGs = "1"
 TSVD = "0.4"
 Test = "1"
 julia = "1.10"
@@ -31,7 +32,8 @@ ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 NMF = "6ef6ca0d-6ad7-5ff6-b225-e928bfa0a386"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "NMF", "Test", "FileIO", "JLD2"]
+test = ["Aqua", "ExplicitImports", "NMF", "Test", "FileIO", "JLD2", "StableRNGs"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This package implements the technique in the paper [GSVD-NMF: Recovering Missing Features in
 Non-negative Matrix Factorization](https://arxiv.org/abs/2408.08260).
-It is used to recover Non-negative matrix factorization(NMF) components from an initial lower-rank factorization by exploiting the generalized singular value decomposition (GSVD) between existing NMF results and the SVD of X.
+It is used to recover Non-negative matrix factorization (NMF) components from an initial lower-rank factorization by exploiting the generalized singular value decomposition (GSVD) between existing NMF results and the SVD of X.
 This method allows the incremental expansion of the number of components, which can be convenient and effective for interactive analysis of large-scale data.
 
 See also [NMFMerge](https://github.com/HolyLab/NMFMerge.jl) for the converse operation. Together, the two result in a substantial improvement in the quality and consistency of NMF factorization.
@@ -23,7 +23,7 @@ pkg> add GsvdInitialization;
 julia> using GsvdInitialization, NMF, LinearAlgebra;
 ```
 
-Generating grouth truth with 10 features.
+Generating ground truth with 10 features.
 
 ```julia
 julia> include("demo/generate_ground_truth.jl")
@@ -92,9 +92,9 @@ In this case, `gsvdnmf` defaults to augment components on initial NMF solution b
 
 Keyword arguments:
 
-- `tol_final`: The tolerence of final NMF, default:`10^{-4}`
+- `tol_final`: The tolerance of final NMF, default:`10^{-4}`
 
-- `tol_intermediate`: The tolerence of initial NMF (under-complete NMF), default: tol_final
+- `tol_intermediate`: The tolerance of initial NMF (under-complete NMF), default: tol_final
 
 Other keyword arguments are passed to `NMF.nnmf`.
 

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -180,7 +180,7 @@ function truncating(X, W0::AbstractMatrix, H0::AbstractMatrix, Hadd::AbstractMat
     m = size(W0, 1)
     kadd = size(Hadd, 1)
     Wadd, a = init_W(X, W0, H0, Hadd)
-    Wadd_nn, Hadd_nn = nndsvd(X, kadd, initdata = (U = Wadd, S = ones(kadd), V = Hadd'))
+    Wadd_nn, Hadd_nn = nndsvd(X, kadd, initdata = (U = Wadd, S = ones(eltype(Wadd), kadd), V = Hadd'))
     W0_1, H0_1 = [repeat(a', m, 1).*W0 Wadd_nn], [H0; Hadd_nn]
     cs = Wcols_modification(X, W0_1, H0_1)
     W0_2, H0_2 = repeat(cs', m, 1).*W0_1, H0_1
@@ -242,7 +242,7 @@ function gram_sp_C(W0, H0, Hadd)
     P = Hadd*H0'
     HH = Hadd*Hadd'
     G22 = sparse(W0W0.*H0H0)
-    G12 = zeros(Float64, mk, r0)
+    G12 = zeros(eltype(W0W0), mk, r0)
     for j in 1:r0
         G12[:,j] .= vec(W0[:,j] * P[:,j]')
     end

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -42,6 +42,14 @@ Keyword arguments:
 
 - `tol_final`: the tolerance of the NMF polishing step, default: 1e-4
 
+- `alg`: the NMF algorithm for the polishing step, forwarded to `NMF.nnmf`,
+  default: `:cd`. When `alg == :multmse` the augmented factors are floored to
+  `truncmult` first, because multiplicative updates require strictly positive
+  factors.
+
+- `truncmult`: the flooring level applied to the augmented factors when
+  `alg == :multmse`, default: 1e-5
+
 Other keyword arguments are passed to `NMF.nnmf`.
 
 Returns the `NMF.NMFResult` from the polishing step (its `W` and `H` fields hold
@@ -63,7 +71,7 @@ function gsvdnmf(strategy, X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatr
     if alg == :multmse
         W_recover, H_recover = max.(W_recover, truncmult), max.(H_recover, truncmult)
     end
-    result_recover = nnmf(X, n2; kwargs..., init=:custom, tol=tol_final, W0=copy(W_recover), H0=copy(H_recover))
+    result_recover = nnmf(X, n2; kwargs..., alg, init=:custom, tol=tol_final, W0=copy(W_recover), H0=copy(H_recover))
     return result_recover, Λ
 end
 gsvdnmf(X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatrix, f; kwargs...) =

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -194,6 +194,10 @@ Alternative `gsvdrecover` strategy that jointly solves for the new columns of
 `W` and the rescaling `α` of existing columns using nonnegative least-squares
 (NNLS). `Hadd` is first projected onto the non-negative orthant.
 
+Beyond the `*` and `sum(abs2, ·)` that the default [`truncating`](@ref) strategy
+needs from `X`, this path also requires `X - W*H` and `eltype(X)` (used while
+projecting `Hadd`).
+
 Returns non-negative `(W_augmented, H_augmented)`.
 """
 function joint_nnls(X, W0::AbstractMatrix, H0::AbstractMatrix, Hadd::AbstractMatrix)
@@ -219,7 +223,7 @@ function init_H(U0::AbstractMatrix, S0::AbstractVector, V0::AbstractMatrix, W0::
     return Hadd_1', Λ
 end
 
-function init_W_joint_nnls(X::AbstractMatrix{T}, W0::AbstractMatrix{T}, H0::AbstractMatrix{T}, Hadd::AbstractMatrix{T}) where T
+function init_W_joint_nnls(X, W0::AbstractMatrix{T}, H0::AbstractMatrix{T}, Hadd::AbstractMatrix{T}) where T
     m = size(X, 1)
     kadd = size(Hadd, 1)
     G = gram_sp_C(W0, H0, Hadd)[1]

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -114,7 +114,7 @@ function gsvdnmf(strategy, X::AbstractMatrix, ncomponents::Pair{<:Integer,<:Inte
     W0, H0 = nndsvd(X, n1; initdata = (U = f[1], S = f[2], V = f[3]))
     result_initial_nmf = nnmf(X, n1; kwargs..., init=:custom, tol=tol_intermediate, W0=copy(W0), H0=copy(H0))
     W_initial_nmf, H_initial_nmf = result_initial_nmf.W, result_initial_nmf.H
-    return gsvdnmf(strategy, X, W_initial_nmf, H_initial_nmf, f; kwargs..., n2=n2, tol_final)
+    return gsvdnmf(strategy, X, W_initial_nmf, H_initial_nmf, f; kwargs..., n2, tol_final)
 end
 gsvdnmf(X::AbstractMatrix, ncomponents::Pair{<:Integer,<:Integer}; kwargs...) =
     gsvdnmf(truncating, X, ncomponents; kwargs...)
@@ -177,13 +177,12 @@ to solve for the new columns of `W` (i.e., `Wadd`).
 Returns non-negative `(W_augmented, H_augmented)`.
 """
 function truncating(X, W0::AbstractMatrix, H0::AbstractMatrix, Hadd::AbstractMatrix)
-    m = size(W0, 1)
     kadd = size(Hadd, 1)
     Wadd, a = init_W(X, W0, H0, Hadd)
     Wadd_nn, Hadd_nn = nndsvd(X, kadd, initdata = (U = Wadd, S = ones(eltype(Wadd), kadd), V = Hadd'))
-    W0_1, H0_1 = [repeat(a', m, 1).*W0 Wadd_nn], [H0; Hadd_nn]
+    W0_1, H0_1 = [a' .* W0 Wadd_nn], [H0; Hadd_nn]
     cs = Wcols_modification(X, W0_1, H0_1)
-    W0_2, H0_2 = repeat(cs', m, 1).*W0_1, H0_1
+    W0_2, H0_2 = cs' .* W0_1, H0_1
     return abs.(W0_2), abs.(H0_2)
 end
 
@@ -201,10 +200,9 @@ projecting `Hadd`).
 Returns non-negative `(W_augmented, H_augmented)`.
 """
 function joint_nnls(X, W0::AbstractMatrix, H0::AbstractMatrix, Hadd::AbstractMatrix)
-    m = size(W0, 1)
     Hadd_nn = truncatepos(Hadd', X, W0, H0)'
     Wadd, a = init_W_joint_nnls(X, W0, H0, Hadd_nn)
-    W0_1, H0_1 = [repeat(a', m, 1).*W0 Wadd], [H0; Hadd_nn]
+    W0_1, H0_1 = [a' .* W0 Wadd], [H0; Hadd_nn]
     return abs.(W0_1), abs.(H0_1)
 end
 
@@ -290,9 +288,6 @@ function obj_para(X, W0::AbstractMatrix{T}, H0::AbstractMatrix{T}, Hadd::Abstrac
 end
 
 function Wcols_modification(X, W::AbstractMatrix{T}, H::AbstractMatrix{T}) where T
-    n = size(W, 2)
-    a = Array{T}(undef, n)
-    B = Array{T}(undef, n, n)
     WW, HH = W'*W, H*H'
     WtXHt = W'*X*H'
     a = diag(WtXHt)

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -157,6 +157,7 @@ function gsvdrecover(strategy, X, W0::AbstractMatrix, H0::AbstractMatrix, kadd::
     _, n = size(W0)
     kadd > 0 || throw(ArgumentError("kadd must be positive; got $kadd"))
     kadd <= n || throw(ArgumentError("# of extra columns must less than 1st NMF components"))
+    size(first(f), 2) >= n || throw(ArgumentError("the supplied SVD has $(size(first(f), 2)) components but size(W0, 2) = $n are required"))
     U0, S0, V0 = f
     U0, S0, V0 = U0[:,1:n], S0[1:n], V0[:,1:n]
     Hadd, Λ = init_H(U0, S0, V0, W0, H0, kadd)

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -65,8 +65,8 @@ function gsvdnmf(strategy, X::AbstractMatrix, W::AbstractMatrix, H::AbstractMatr
     n1 = size(W, 2)
     kadd = n2 - n1
     kadd > 0 || throw(ArgumentError("The number of components to add must be positive; got n2 = $n2, size(W, 2) = $n1"))
-    kadd <= n1 || throw(ArgumentError("The number of components to add must be less than initial number of components"))
-    size(first(f), 2) >= n1 || throw(ArgumentError("The supplied SVD does not have enough components"))
+    kadd <= n1 || throw(ArgumentError("The number of components to add must be at most the initial number of components; got kadd = $kadd, size(W, 2) = $n1"))
+    size(first(f), 2) >= n1 || throw(ArgumentError("The supplied SVD has $(size(first(f), 2)) components but size(W, 2) = $n1 are required"))
     W_recover, H_recover, Λ = gsvdrecover(strategy, X, copy(W), copy(H), kadd, f)
     if alg == :multmse
         W_recover, H_recover = max.(W_recover, truncmult), max.(H_recover, truncmult)
@@ -102,9 +102,9 @@ In this case, `gsvdnmf` defaults to augment components on initial NMF solution b
 
 Keyword arguments:
 
-- `tol_final`: The tolerence of final NMF, default:`10^{-4}`
+- `tol_final`: The tolerance of final NMF, default:`10^{-4}`
 
-- `tol_intermediate`: The tolerence of initial NMF (under-complete NMF), default: tol_final
+- `tol_intermediate`: The tolerance of initial NMF (under-complete NMF), default: tol_final
 
 Other keyword arguments are passed to `NMF.nnmf`.
 """
@@ -156,7 +156,7 @@ Arguments:
 function gsvdrecover(strategy, X, W0::AbstractMatrix, H0::AbstractMatrix, kadd::Integer, f)
     _, n = size(W0)
     kadd > 0 || throw(ArgumentError("kadd must be positive; got $kadd"))
-    kadd <= n || throw(ArgumentError("# of extra columns must less than 1st NMF components"))
+    kadd <= n || throw(ArgumentError("the number of extra columns must be at most size(W0, 2); got kadd = $kadd, size(W0, 2) = $n"))
     size(first(f), 2) >= n || throw(ArgumentError("the supplied SVD has $(size(first(f), 2)) components but size(W0, 2) = $n are required"))
     U0, S0, V0 = f
     U0, S0, V0 = U0[:,1:n], S0[1:n], V0[:,1:n]
@@ -211,7 +211,7 @@ function init_H(U0::AbstractMatrix, S0::AbstractVector, V0::AbstractMatrix, W0::
     r0 = size(U0, 2)
     k = findfirst(x->x!=0, D2[1,:])
     k = (k === nothing) ? r0 : k-1
-    kadd >= k || @warn "kadd is less than rank deficiency of W0*H0."
+    kadd >= k || @warn "kadd ($kadd) is less than the rank deficiency of W0*H0 ($k)."
     F = (diag(D1[k+1:r0, k+1:r0])./diag(D2[1:r0-k,k+1:r0])).^2
     Λ = vcat(fill(Inf, k), F)
     H_index = sortperm(Λ, rev = true)[1:kadd]

--- a/src/GsvdInitialization.jl
+++ b/src/GsvdInitialization.jl
@@ -1,6 +1,6 @@
 module GsvdInitialization
 
-using LinearAlgebra: Diagonal, I, Symmetric, diag, isposdef, svd
+using LinearAlgebra: Diagonal, I, Symmetric, UpperTriangular, cholesky, diag, isposdef, svd, tr
 using NMF: NMF, nnmf, nndsvd
 using TSVD: tsvd
 using NonNegLeastSquares: nonneg_lsq
@@ -208,7 +208,6 @@ end
 
 function init_H(U0::AbstractMatrix, S0::AbstractVector, V0::AbstractMatrix, W0::AbstractMatrix, H0::AbstractMatrix, kadd::Integer)
     _, _, Q, D1, D2, R = svd(Matrix(Diagonal(S0)), (U0'*W0)*(H0*V0));
-    inv_RQt = inv(R*Q')
     r0 = size(U0, 2)
     k = findfirst(x->x!=0, D2[1,:])
     k = (k === nothing) ? r0 : k-1
@@ -216,7 +215,14 @@ function init_H(U0::AbstractMatrix, S0::AbstractVector, V0::AbstractMatrix, W0::
     F = (diag(D1[k+1:r0, k+1:r0])./diag(D2[1:r0-k,k+1:r0])).^2
     Λ = vcat(fill(Inf, k), F)
     H_index = sortperm(Λ, rev = true)[1:kadd]
-    Hadd = inv_RQt[:, H_index]
+    # Columns of inv(R*Q') = Q*inv(R) selected by H_index, via a triangular
+    # backsolve on just those right-hand sides: the GSVD's Q is orthogonal and
+    # R is square upper triangular (Diagonal(S0) is nonsingular, so k+l = r0).
+    E = zeros(eltype(R), size(R, 1), length(H_index))
+    for (j, idx) in enumerate(H_index)
+        E[idx, j] = 1
+    end
+    Hadd = Q * (UpperTriangular(R) \ E)
     Hadd_1 = V0*Hadd
     return Hadd_1', Λ
 end
@@ -256,7 +262,7 @@ function gram_b(X, W0, H0, Hadd)
 end
 
 function init_W(X, W0::AbstractMatrix{T}, H0::AbstractMatrix{T}, Hadd::AbstractMatrix{T}; α = nothing) where T
-    A, b, _, invHH, H0Hadd, XHaddt = obj_para(X, W0, H0, Hadd)
+    A, b, _, cholHH, H0Hadd, XHaddt = obj_para(X, W0, H0, Hadd)
     if α === nothing
         if isposdef(A)
             α = nonneg_lsq(A, -b; alg=:fnnls, gram=true)
@@ -268,7 +274,7 @@ function init_W(X, W0::AbstractMatrix{T}, H0::AbstractMatrix{T}, Hadd::AbstractM
             α = ones(T, size(A, 1))
         end
     end
-    Wadd = XHaddt*invHH-W0*Diagonal(α[:])*H0Hadd*invHH
+    Wadd = (XHaddt - W0*Diagonal(α[:])*H0Hadd) / cholHH
     return Wadd, abs.(α)
 end
 
@@ -278,13 +284,13 @@ function obj_para(X, W0::AbstractMatrix{T}, H0::AbstractMatrix{T}, Hadd::Abstrac
     HH = Hadd*Hadd'
     W0W0 = W0'*W0
     H0H0 = H0*H0'
-    invHH = inv(HH)
-    A = W0W0.*(H0H0-H0Hadd*invHH*H0Hadd')
+    cholHH = cholesky(Symmetric(HH))
+    A = W0W0.*(H0H0-H0Hadd*(cholHH \ H0Hadd'))
     W0tXH0t = W0'*X*H0'
     W0XHaddt = W0'*XHaddt
-    b = diag(H0Hadd*invHH*W0XHaddt'-W0tXH0t)
-    C = sum(abs2, X)-sum(invHH.*(XHaddt'*XHaddt))
-    return Symmetric(A), b, C, invHH, H0Hadd, XHaddt
+    b = diag(H0Hadd*(cholHH \ W0XHaddt')-W0tXH0t)
+    C = sum(abs2, X)-tr(cholHH \ (XHaddt'*XHaddt))
+    return Symmetric(A), b, C, cholHH, H0Hadd, XHaddt
 end
 
 function Wcols_modification(X, W::AbstractMatrix{T}, H::AbstractMatrix{T}) where T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -169,6 +169,18 @@ end
     @test Hd_j ≈ Hf_j
 end
 
+@testset "eltype genericity" begin
+    # The default (`truncating`) path must preserve the input eltype rather than
+    # silently promoting to `Float64`.
+    W = rand(Float32, 12, 4)
+    H = rand(Float32, 4, 9)
+    X = W * H
+    fs = svd(X)
+    Wa, Ha, _ = gsvdrecover(X, copy(W), copy(H), 2, (fs.U, fs.S, fs.V))
+    @test eltype(Wa) === Float32
+    @test eltype(Ha) === Float32
+end
+
 @testset "integer-typed component counts" begin
     X = rand(30, 20)
     # Non-`Int` integer types (e.g. `Int32`) must dispatch on the same methods

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,12 @@ svdX = load_svd_of_gt()
     @test_throws ArgumentError gsvdnmf(X, Wfit, Hfit, (f.U, f.S, f.V); n2 = 5)
     @test_throws "must be positive" gsvdnmf(X, Wfit, Hfit, (f.U, f.S, f.V); n2 = 5)
     @test_throws "must be positive" gsvdrecover(X, Wfit, Hfit, 0, (f.U, f.S, f.V))
+
+    # `alg` must reach the polishing `nnmf`.  An unknown algorithm name is
+    # rejected by `nnmf` only if `alg` is forwarded; the polishing call is the
+    # sole `nnmf` invocation in this four-argument path.
+    Waug, Haug = rand(30, 9), rand(9, 20)
+    @test_throws "Invalid algorithm" gsvdnmf(X, Waug, Haug, (f.U, f.S, f.V); n2 = 10, alg = :__nonexistent__)
 end
 
 @testset "GsvdInitialization" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,6 +68,11 @@ svdX = load_svd_of_gt()
     @test_throws "must be positive" gsvdnmf(X, Wfit, Hfit, (f.U, f.S, f.V); n2 = 5)
     @test_throws "must be positive" gsvdrecover(X, Wfit, Hfit, 0, (f.U, f.S, f.V))
 
+    # An SVD with fewer components than `size(W0, 2)` cannot seed the
+    # generalized SVD; reject it with a clear message rather than a BoundsError.
+    fsmall = (f.U[:, 1:3], f.S[1:3], f.V[:, 1:3])
+    @test_throws "has 3 components but size(W0, 2) = 5" gsvdrecover(X, Wfit, Hfit, 1, fsmall)
+
     # `alg` must reach the polishing `nnmf`.  An unknown algorithm name is
     # rejected by `nnmf` only if `alg` is forwarded; the polishing call is the
     # sole `nnmf` invocation in this four-argument path.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,9 @@ Base.size(F::MockFactored, d) = d == 1 ? size(F.U, 1) : (d == 2 ? size(F.V, 2) :
 Base.:*(F::MockFactored, A::AbstractMatrix) = F.U * (F.V * A)
 Base.:*(A::AbstractMatrix, F::MockFactored) = (A * F.U) * F.V
 Base.sum(::typeof(abs2), F::MockFactored) = sum((F.U' * F.U) .* (F.V * F.V'))
+# `joint_nnls`'s `truncatepos` step needs `X - W*H`; materializing densely here
+# is fine — the point is that no `AbstractArray` constraint rejects `X`.
+Base.:-(F::MockFactored, A::AbstractMatrix) = F.U * F.V - A
 
 include(joinpath(dirname(@__DIR__), "demo/generate_ground_truth.jl"))
 
@@ -152,6 +155,18 @@ end
     Wf, Hf, _ = GsvdInitialization.gsvdrecover(Xfact,  copy(W0), copy(H0), 2, f)
     @test Wd ≈ Wf
     @test Hd ≈ Hf
+
+    # The `joint_nnls` strategy also accepts a factored `X` (it needs `X - W*H`
+    # and `eltype(X)` on top of `*`/`sum(abs2, ·)`).
+    Wjd, ajd = GsvdInitialization.init_W_joint_nnls(Xdense, W0, H0, Hadd)
+    Wjf, ajf = GsvdInitialization.init_W_joint_nnls(Xfact,  W0, H0, Hadd)
+    @test Wjd ≈ Wjf
+    @test ajd ≈ ajf
+
+    Wd_j, Hd_j, _ = GsvdInitialization.gsvdrecover(GsvdInitialization.joint_nnls, Xdense, copy(W0), copy(H0), 2, f)
+    Wf_j, Hf_j, _ = GsvdInitialization.gsvdrecover(GsvdInitialization.joint_nnls, Xfact,  copy(W0), copy(H0), 2, f)
+    @test Wd_j ≈ Wf_j
+    @test Hd_j ≈ Hf_j
 end
 
 @testset "integer-typed component counts" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,13 +57,17 @@ svdX = load_svd_of_gt()
     @test sum(abs2, X-standard_nmf.W*standard_nmf.H)/sum(abs2, X) > sum(abs2, X-W_gsvd*H_gsvd)/sum(abs2, X)
     @test length(Λ_gsvd) == 9
 
+    # `gsvdnmf(X, n2)` is sugar for `gsvdnmf(X, n2-1 => n2)`.  The two calls run
+    # the same pipeline, so they agree only up to the ~1e-9 nondeterminism of
+    # multithreaded BLAS in `nnmf`; `rtol = 1e-6` stays far tighter than the
+    # `1e-4` NMF tol.
     X = rand(rng, 30, 20)
     result_1, _ = gsvdnmf(X, 10; alg=:cd)
     result_2, _ = gsvdnmf(X, 9 => 10; alg=:cd)
     W_gsvd_1, H_gsvd_1 = result_1.W, result_1.H
     W_gsvd_2, H_gsvd_2 = result_2.W, result_2.H
-    @test sum(abs2, W_gsvd_1-W_gsvd_2) <= 1e-12
-    @test sum(abs2, H_gsvd_1-H_gsvd_2) <= 1e-12
+    @test isapprox(W_gsvd_1, W_gsvd_2; rtol = 1e-6)
+    @test isapprox(H_gsvd_1, H_gsvd_2; rtol = 1e-6)
 
     # n2 == size(W, 2) is a caller bug: there is nothing to augment.  Reject it
     # eagerly rather than silently returning the input factorization.
@@ -194,15 +198,17 @@ end
     rng = StableRNG(5)
     X = rand(rng, 30, 20)
     # Non-`Int` integer types (e.g. `Int32`) must dispatch on the same methods
-    # as plain `Int` — no `MethodError` from over-tight signatures.
+    # as plain `Int` — no `MethodError` from over-tight signatures.  Each pair
+    # runs the same pipeline twice, so `rtol = 1e-6` for the same reason as the
+    # cross-call checks in "test top wrapper".
     r_int,   _ = gsvdnmf(X, 9 => 10; alg = :cd)
     r_int32, _ = gsvdnmf(X, Int32(9) => Int32(10); alg = :cd)
-    @test r_int.W ≈ r_int32.W
-    @test r_int.H ≈ r_int32.H
+    @test isapprox(r_int.W, r_int32.W; rtol = 1e-6)
+    @test isapprox(r_int.H, r_int32.H; rtol = 1e-6)
 
     r_n2_int,   _ = gsvdnmf(X, 10; alg = :cd)
     r_n2_int32, _ = gsvdnmf(X, Int32(10); alg = :cd)
-    @test r_n2_int.W ≈ r_n2_int32.W
+    @test isapprox(r_n2_int.W, r_n2_int32.W; rtol = 1e-6)
 
     # `gsvdrecover` likewise accepts a non-`Int` `kadd`.
     Wfit, Hfit = rand(rng, 30, 4), rand(rng, 4, 20)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Aqua
 using ExplicitImports
 
 using LinearAlgebra, NMF, FileIO
+using StableRNGs
 
 @testset "Aqua" begin
     Aqua.test_all(GsvdInitialization)
@@ -44,6 +45,7 @@ W_GT, H_GT = generate_ground_truth()
 svdX = load_svd_of_gt()
 
 @testset "test top wrapper" begin
+    rng = StableRNG(1)
     W = W_GT
     H = H_GT
     X = W*H
@@ -55,7 +57,7 @@ svdX = load_svd_of_gt()
     @test sum(abs2, X-standard_nmf.W*standard_nmf.H)/sum(abs2, X) > sum(abs2, X-W_gsvd*H_gsvd)/sum(abs2, X)
     @test length(Λ_gsvd) == 9
 
-    X = rand(30, 20)
+    X = rand(rng, 30, 20)
     result_1, _ = gsvdnmf(X, 10; alg=:cd)
     result_2, _ = gsvdnmf(X, 9 => 10; alg=:cd)
     W_gsvd_1, H_gsvd_1 = result_1.W, result_1.H
@@ -65,7 +67,7 @@ svdX = load_svd_of_gt()
 
     # n2 == size(W, 2) is a caller bug: there is nothing to augment.  Reject it
     # eagerly rather than silently returning the input factorization.
-    Wfit, Hfit = rand(30, 5), rand(5, 20)
+    Wfit, Hfit = rand(rng, 30, 5), rand(rng, 5, 20)
     f = svd(X)
     @test_throws ArgumentError gsvdnmf(X, Wfit, Hfit, (f.U, f.S, f.V); n2 = 5)
     @test_throws "must be positive" gsvdnmf(X, Wfit, Hfit, (f.U, f.S, f.V); n2 = 5)
@@ -83,43 +85,44 @@ svdX = load_svd_of_gt()
     # `alg` must reach the polishing `nnmf`.  An unknown algorithm name is
     # rejected by `nnmf` only if `alg` is forwarded; the polishing call is the
     # sole `nnmf` invocation in this four-argument path.
-    Waug, Haug = rand(30, 9), rand(9, 20)
+    Waug, Haug = rand(rng, 30, 9), rand(rng, 9, 20)
     @test_throws "Invalid algorithm" gsvdnmf(X, Waug, Haug, (f.U, f.S, f.V); n2 = 10, alg = :__nonexistent__)
 end
 
 @testset "GsvdInitialization" begin
-    W, H = rand(10, 3), rand(3, 8)
+    rng = StableRNG(2)
+    W, H = rand(rng, 10, 3), rand(rng, 3, 8)
     X = W*H
     U, S, V = svd(X)
 
     W0, H0 = copy(W), copy(H)
-    Hadd = rand(2, 8)
+    Hadd = rand(rng, 2, 8)
     Wadd, a = GsvdInitialization.init_W(X, W0, H0, Hadd)
     @test a ≈ ones(size(W0, 2))
     @test norm(Wadd) <= 1e-8
-    
+
     W0, H0 = zero(W), zero(H)
     Hadd = V[:,1:3]'
     Wadd, a = GsvdInitialization.init_W(X, W0, H0, Hadd)
     @test sum(abs2, Wadd-(U*Diagonal(S))[:,1:3]) <= 1e-12
 
-    W0, H0 = rand(10, 4), rand(4, 8)
-    Hadd = rand(2, 8)
+    W0, H0 = rand(rng, 10, 4), rand(rng, 4, 8)
+    Hadd = rand(rng, 2, 8)
     A, b, C, HH, γ = GsvdInitialization.obj_para(X, W0, H0, Hadd)
-    a = rand(4)
+    a = rand(rng, 4)
     Wadd, a = GsvdInitialization.init_W(X, W0, H0, Hadd, α = a)
     E = a'*A*a+2*b'*a+C
     @test abs(E-sum(abs2, X-[repeat(a', size(W0, 1)).*W0 Wadd]*[H0;Hadd])) <= 1e-12
 
-    β0 = rand(3)
+    β0 = rand(rng, 3)
     β = GsvdInitialization.Wcols_modification(X, repeat(β0', size(W, 1)).*W, H)
     @test β.*β0 ≈ ones(3)
 
     # When H0 is parallel to Hadd the Schur complement vanishes and A = 0, making
     # the QP degenerate.  init_W must return finite results rather than throwing
     # SingularException (which fnnls raises on Julia ≥ 1.12 for a zero pivot).
-    W0_deg = rand(Float64, 5, 1)
-    H0_deg = rand(Float64, 1, 8)
+    W0_deg = rand(rng, Float64, 5, 1)
+    H0_deg = rand(rng, Float64, 1, 8)
     X_deg  = W0_deg * H0_deg
     Hadd_deg = H0_deg   # parallel to H0 → Schur complement = 0 → A = 0
     Wadd_deg, a_deg = GsvdInitialization.init_W(X_deg, W0_deg, H0_deg, Hadd_deg)
@@ -133,12 +136,13 @@ end
 # dense product never be materialized, which matters when `X` would otherwise
 # be the largest array per call.
 @testset "non-AbstractArray X" begin
-    U = rand(10, 3)
-    V = rand(3, 8)
+    rng = StableRNG(3)
+    U = rand(rng, 10, 3)
+    V = rand(rng, 3, 8)
     Xdense = U * V
     Xfact  = MockFactored(U, V)
-    W0, H0 = rand(10, 4), rand(4, 8)
-    Hadd   = rand(2, 8)
+    W0, H0 = rand(rng, 10, 4), rand(rng, 4, 8)
+    Hadd   = rand(rng, 2, 8)
     fs     = svd(Xdense)
     f      = (fs.U, fs.S, fs.V)
 
@@ -149,7 +153,7 @@ end
     @test a_d    ≈ a_f
 
     # `Wcols_modification` likewise.
-    β0 = rand(4)
+    β0 = rand(rng, 4)
     W_scaled = repeat(β0', size(W0, 1)) .* W0
     @test GsvdInitialization.Wcols_modification(Xdense, W_scaled, H0) ≈
           GsvdInitialization.Wcols_modification(Xfact,  W_scaled, H0)
@@ -176,8 +180,9 @@ end
 @testset "eltype genericity" begin
     # The default (`truncating`) path must preserve the input eltype rather than
     # silently promoting to `Float64`.
-    W = rand(Float32, 12, 4)
-    H = rand(Float32, 4, 9)
+    rng = StableRNG(4)
+    W = rand(rng, Float32, 12, 4)
+    H = rand(rng, Float32, 4, 9)
     X = W * H
     fs = svd(X)
     Wa, Ha, _ = gsvdrecover(X, copy(W), copy(H), 2, (fs.U, fs.S, fs.V))
@@ -186,7 +191,8 @@ end
 end
 
 @testset "integer-typed component counts" begin
-    X = rand(30, 20)
+    rng = StableRNG(5)
+    X = rand(rng, 30, 20)
     # Non-`Int` integer types (e.g. `Int32`) must dispatch on the same methods
     # as plain `Int` — no `MethodError` from over-tight signatures.
     r_int,   _ = gsvdnmf(X, 9 => 10; alg = :cd)
@@ -199,29 +205,33 @@ end
     @test r_n2_int.W ≈ r_n2_int32.W
 
     # `gsvdrecover` likewise accepts a non-`Int` `kadd`.
-    Wfit, Hfit = rand(30, 4), rand(4, 20)
+    Wfit, Hfit = rand(rng, 30, 4), rand(rng, 4, 20)
     f = svd(X)
     Wa, Ha, _ = gsvdrecover(X, Wfit, Hfit, Int32(1), (f.U, f.S, f.V))
     @test size(Wa, 2) == 5
 end
 
 @testset "strategy dispatch" begin
-    X = rand(30, 20)
-    # explicit `truncating` matches the no-strategy default
+    rng = StableRNG(6)
+    X = rand(rng, 30, 20)
+    # explicit `truncating` matches the no-strategy default.  These run the same
+    # strategy, so they agree up to the ~1e-9 nondeterminism of multithreaded
+    # BLAS in `nnmf`; `rtol = 1e-6` stays far tighter than the `1e-4` NMF tol.
     r_default, _ = gsvdnmf(X, 9 => 10; alg = :cd)
     r_explicit, _ = gsvdnmf(GsvdInitialization.truncating, X, 9 => 10; alg = :cd)
-    @test r_default.W ≈ r_explicit.W
-    @test r_default.H ≈ r_explicit.H
+    @test isapprox(r_default.W, r_explicit.W; rtol = 1e-6)
+    @test isapprox(r_default.H, r_explicit.H; rtol = 1e-6)
 
     # do-block form: anonymous strategy that simply forwards to `truncating`
     r_doblock, _ = gsvdnmf(X, 9 => 10; alg = :cd) do X0, W0, H0, Hadd
         GsvdInitialization.truncating(X0, W0, H0, Hadd)
     end
-    @test r_doblock.W ≈ r_default.W
-    @test r_doblock.H ≈ r_default.H
+    @test isapprox(r_doblock.W, r_default.W; rtol = 1e-6)
+    @test isapprox(r_doblock.H, r_default.H; rtol = 1e-6)
 end
 
 @testset "joint optimize W and alpha" begin
+    rng = StableRNG(7)
     W = W_GT
     H = H_GT
     X = W*H
@@ -230,20 +240,20 @@ end
     @test size(W_gsvd, 2) == 10
     @test sum(abs2, X-W_gsvd*H_gsvd)/sum(abs2, X) < 2e-10
 
-    W, H = rand(10, 3), rand(3, 8)
+    W, H = rand(rng, 10, 3), rand(rng, 3, 8)
     X = W*H
     U, S, V = svd(X)
 
     W0, H0 = copy(W), copy(H)
-    Hadd = rand(2, 8)
+    Hadd = rand(rng, 2, 8)
     Wadd, a = GsvdInitialization.init_W_joint_nnls(X, W0, H0, Hadd)
     @test a ≈ ones(size(W0, 2))
     @test norm(Wadd) <= 1e-8
 
     G = GsvdInitialization.gram_sp_C(W0, H0, Hadd)[1]
     b = GsvdInitialization.gram_b(X, W0, H0, Hadd)
-    Wadd = rand(10, 2)
-    α = rand(3)
+    Wadd = rand(rng, 10, 2)
+    α = rand(rng, 3)
     θ = vcat(vec(Wadd), α)
     E = θ'*G*θ-2*b'*θ+sum(abs2, X)
     @test abs(E-sum(abs2, X-[repeat(α', size(W0, 1)).*W0 Wadd]*[H0;Hadd])) <= 1e-12

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,10 @@ svdX = load_svd_of_gt()
     fsmall = (f.U[:, 1:3], f.S[1:3], f.V[:, 1:3])
     @test_throws "has 3 components but size(W0, 2) = 5" gsvdrecover(X, Wfit, Hfit, 1, fsmall)
 
+    # A single call augments by at most the current number of components.
+    @test_throws "must be at most the initial number of components" gsvdnmf(X, Wfit, Hfit, (f.U, f.S, f.V); n2 = 11)
+    @test_throws "must be at most size(W0, 2)" gsvdrecover(X, Wfit, Hfit, 6, (f.U, f.S, f.V))
+
     # `alg` must reach the polishing `nnmf`.  An unknown algorithm name is
     # rejected by `nnmf` only if `alg` is forwarded; the polishing call is the
     # sole `nnmf` invocation in this four-argument path.


### PR DESCRIPTION
This collects the fixes from a dependency-interface and friction review of the package (#29).

## Bug fixes

- **`gsvdnmf` now forwards `alg` to the NMF polishing step** (945c7d7). The keyword was accepted and used for the `:multmse` flooring check, but the polishing `nnmf` call ignored it and always ran NMF.jl's default algorithm. Restores the documented "other keyword arguments are passed to `NMF.nnmf`" contract; polishing results change at the convergence level for callers who passed a non-default `alg`.
- **`gsvdrecover` validates the SVD width** (16af4e4). An SVD with fewer than `size(W0, 2)` components now raises an `ArgumentError` reporting both numbers, instead of a raw `BoundsError`.

## Genericity

- **`joint_nnls` accepts factored `X`** (ca0d8c9). `init_W_joint_nnls` was the only helper still constraining `X::AbstractMatrix`, contradicting the duck-typed-`X` convention (#21). The joint path needs `X - W*H` and `eltype(X)` beyond the `*`/`sum(abs2, ·)` the default strategy uses; this is documented and covered by the `MockFactored` tests.
- **The `truncating` path preserves the input eltype** (7a60b5c). Two hardcoded `Float64` containers silently promoted `Float32` problems. A `Float32` round-trip test asserts the output eltype. Note: this exposes a pre-existing limitation of the `joint_nnls` path — its sparse Gram solve routes through CHOLMOD (Float64-only), so non-Float64 joint problems now fail instead of being silently promoted. This is more of an issue for NonNegLeastSquares.jl than this package.

## Numerical hygiene

- **Factorization-based solves instead of explicit inverses** (2c46929). `init_H` exploits the GSVD structure (`Q` orthogonal, `R` square upper triangular) to obtain the selected columns of `inv(R*Q')` by triangular backsolve; `obj_para`/`init_W` factor the `Hadd` Gram once with Cholesky and reuse it via `\` and `/`. Results unchanged up to roundoff; the algebraic-identity tests pass at their original `1e-12` tolerances.

## Cleanups, messages, docs

- Broadcast `v' .* M` instead of materializing `repeat(v', m, 1)`; drop dead allocations; short-form keyword (efec0ee).
- Validation messages now match the checks ("at most", not "less than") and report the offending values; the `init_H` warning reports `kadd` and the rank deficiency; spelling fixes in README and docstrings (2513b73).

## Test reproducibility

- Every synthetic test problem is now built from a per-testset `StableRNG` seed (3840daa), so the tight tolerances can't fail on an unlucky draw.
- All tests that compare two runs of the same NMF pipeline (no-strategy default vs explicit strategy, integer sugar form vs `Pair` form, `Int` vs `Int32` arguments) now assert `rtol = 1e-6` instead of near-exact equality (3840daa, 6c05dcf): the pipeline is only reproducible to ~1e-9 under multithreaded BLAS, and 1e-6 stays far below the 1e-4 NMF convergence tolerance.

Tests: 60/60 pass (up from 50 at baseline); `detect_ambiguities` count unchanged at 0. No exported API changes.

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
